### PR TITLE
Remove public from install generator

### DIFF
--- a/lib/generators/spree_static_content/install_generator.rb
+++ b/lib/generators/spree_static_content/install_generator.rb
@@ -9,10 +9,6 @@ module SpreeStaticContent
         directory "db"
       end
 
-      def copy_public
-        directory "public"
-      end
-
     end
   end
 end


### PR DESCRIPTION
Now that WYM is no longer included, the install generator should not attempt to copy the public directory as it has been removed and results in a mis-leading error when it is executed.
