### PR TITLE
fix meta keywords && meta_description

### DIFF
--- a/app/controllers/spree/base_controller_decorator.rb
+++ b/app/controllers/spree/base_controller_decorator.rb
@@ -16,6 +16,10 @@ Spree::BaseController.class_eval do
     return if Rails.cache.fetch('page_not_exist/'+request.path)
 
     if @page = Page.visible.find_by_slug(request.path)
+
+      #load @content object to load correct meta_keywords & meta_description
+      @content = @page
+      
       if @page.layout && !@page.layout.empty?
         render :template => 'static_content/show', :layout => @page.layout
       else

--- a/app/views/static_content/show.html.erb
+++ b/app/views/static_content/show.html.erb
@@ -1,11 +1,5 @@
 <% content_for :head do -%>
   <meta name="title" content="<%=@page.title%>">
-  <% if @page.attribute_present? :meta_keywords -%>
-    <meta name="keywords" content="<%=@page.meta_keywords%>">
-  <% end -%>
-  <% if @page.attribute_present? :meta_description -%>
-    <meta name="description" content="<%=@page.meta_description%>">
-  <% end -%>
 <% end -%>
 <% content_for :sidebar do %>
   <% if "products" == @current_controller && @taxon %>


### PR DESCRIPTION
Actually meta_keywords and meta_description are in double in the html page.

I'm not sure that is the best solution but it's work
