### PR TITLE
Creating page with title + foreign_link will cause NoMethodError

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -33,8 +33,10 @@ private
       end
     end
 
-    self.slug = slug_link
-    Rails.cache.delete('page_not_exist/' + self.slug)
+    if not_using_foreign_link?
+      self.slug = slug_link
+      Rails.cache.delete('page_not_exist/' + self.slug)
+    end
     return true
   end
   


### PR DESCRIPTION
If you create page using a foreign link, e.g. Page.create( :title => "fubar", :foreign_link => "http://github.com"), you will get NoMethodError:

```
NoMethodError: You have a nil object when you didn't expect it!
You might have expected an instance of Array.
The error occurred while evaluating nil.index
```
