### PR TITLE
Compatibility: Rails 3.1 asset pipeline

### DIFF
--- a/lib/generators/spree_static_content/install_generator.rb
+++ b/lib/generators/spree_static_content/install_generator.rb
@@ -1,24 +1,45 @@
-module SpreeStaticContent
-  module Generators
-    class InstallGenerator < Rails::Generators::Base
+if ::Rails.version < "3.1" || !::Rails.application.config.assets.enabled
+  module SpreeStaticContent
+    module Generators
+      class InstallGenerator < Rails::Generators::Base
 
-      def add_stylesheets
-        inject_into_file "app/assets/stylesheets/admin/all.css", " *= require formtastic\n", :before => /\*\//, :verbose => true
+        def add_stylesheets
+          inject_into_file "app/assets/stylesheets/admin/all.css", " *= require formtastic\n", :before => /\*\//, :verbose => true
+        end
+
+        def add_migrations
+          run 'rake railties:install:migrations FROM=spree_static_content'
+        end
+
+        def run_migrations
+           res = ask "Would you like to run the migrations now? [Y/n]"
+           if res == "" || res.downcase == "y"
+             run 'rake db:migrate'
+           else
+             puts "Skiping rake db:migrate, don't forget to run it!"
+           end
+        end
       end
+    end
+  end
+else
+  module SpreeStaticContent
+    module Generators
+      class InstallGenerator < Rails::Generators::Base
+        def add_migrations
+          run 'rake railties:install:migrations FROM=spree_static_content'
+        end
 
-      def add_migrations
-        run 'rake railties:install:migrations FROM=spree_static_content'
-      end
+        def run_migrations
+           res = ask "Would you like to run the migrations now? [Y/n]"
+           if res == "" || res.downcase == "y"
+             run 'rake db:migrate'
+           else
+             puts "Skiping rake db:migrate, don't forget to run it!"
+           end
+        end
 
-      def run_migrations
-         res = ask "Would you like to run the migrations now? [Y/n]"
-         if res == "" || res.downcase == "y"
-           run 'rake db:migrate'
-         else
-           puts "Skiping rake db:migrate, don't forget to run it!"
-         end
       end
     end
   end
 end
-


### PR DESCRIPTION
If the asset pipeline is enabled and it looks for none existent files and fail. Fix for Rails >= 3.1 (and Rails.application.config.assets.enabled.)
