### PR TITLE
Fix: controller location

### DIFF
--- a/app/controllers/spree/admin/pages_controller.rb
+++ b/app/controllers/spree/admin/pages_controller.rb
@@ -11,6 +11,6 @@ class Spree::Admin::PagesController < Spree::Admin::ResourceController
 
   private
   def expire_cache
-    expire_page :controller => '/static_content', :action => 'show', :path => @object.slug
+    expire_page :controller => '/spree/static_content', :action => 'show', :path => @object.slug
   end
 end


### PR DESCRIPTION
Rails looks for a controller only within admin instead of spree.
