### PR TITLE
Update Gemfile to exclude ruby-debug installation on travis-ci.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://production.cf.rubygems.org/'
+source 'http://rubygems.org/'
 
 gem 'spree', :git => "git://github.com/spree/spree.git"
 
@@ -6,10 +6,13 @@ group :test do
   gem 'ffaker'
 end
 
-if RUBY_VERSION < "1.9"
-  gem "ruby-debug"
-else
-  gem "ruby-debug19"
+
+unless ENV["CI"]
+  if RUBY_VERSION < "1.9"
+    gem "ruby-debug"
+  else
+    gem "ruby-debug19"
+  end
 end
 
 gemspec


### PR DESCRIPTION
ruby-debug installation takes a long time and bundle install times out. While it is possible to increase timeouts, lets try this first.
