### PR TITLE
1 0 stable

### DIFF
--- a/app/controllers/spree/static_content_controller.rb
+++ b/app/controllers/spree/static_content_controller.rb
@@ -11,8 +11,9 @@ class Spree::StaticContentController < Spree::BaseController
     when nil
       request.path
     end
-    path = StaticPage::remove_spree_mount_point(path) unless Rails.application.routes.named_routes[:spree].path == "/"
     path = path.gsub('//','/')
+    path = StaticPage::remove_spree_mount_point(path) unless Rails.application.routes.named_routes[:spree].path == "/"
+    
     unless @page = Spree::Page.visible.find_by_slug(path)
       render_404
     end


### PR DESCRIPTION
This fixed the issue of loading the first page in the table no matter what static page you go to.  This only happens in production for some reason.

Per the issue here: https://github.com/spree/spree_static_content/issues/42

It seems that the root path is returned as "//" instead of of "/" and is passing the conditional to be handled by "spree_remove_mount_point."  Moving the gsub call earlier makes it fail that conditional if Spree is mounted at the root.

The "//" seems to be a recurring rails issue.
