### PR TITLE
Fix caching expiration

### DIFF
--- a/app/controllers/spree/admin/pages_controller.rb
+++ b/app/controllers/spree/admin/pages_controller.rb
@@ -11,6 +11,6 @@ class Spree::Admin::PagesController < Spree::Admin::ResourceController
 
   private
   def expire_cache
-    expire_page :controller => '/spree/static_content', :action => 'show', :path => @object.slug
+    expire_fragment "spree_static_content" + @object.slug
   end
 end

--- a/app/controllers/spree/static_content_controller.rb
+++ b/app/controllers/spree/static_content_controller.rb
@@ -1,5 +1,8 @@
 class Spree::StaticContentController < Spree::BaseController
-  caches_action :show
+  caches_action :show, :cache_path => Proc.new { |controller|
+    "spree_static_content/" + controller.params[:path]
+  }
+  
   layout :determine_layout
   
   def show


### PR DESCRIPTION
While pages do indeed get cached, they are not being expired when the page is edited.  So, there's really no way to modify a page unless you clear the cache.

It has to do with the cache path being used, and I think the way the routing is set up for this extension messes up the caching path.  In any case, I modified the way the cache path is created and used, so this should work regardless of future routing changes.
