### PR TITLE
Caching broken for root URL

### DIFF
--- a/app/controllers/spree/admin/pages_controller.rb
+++ b/app/controllers/spree/admin/pages_controller.rb
@@ -11,6 +11,6 @@ class Spree::Admin::PagesController < Spree::Admin::ResourceController
 
   private
   def expire_cache
-    expire_fragment "spree_static_content" + @object.slug
+    expire_fragment "spree_static_content" + @object.slug + "_spree_static_content"
   end
 end

--- a/app/controllers/spree/static_content_controller.rb
+++ b/app/controllers/spree/static_content_controller.rb
@@ -1,6 +1,6 @@
 class Spree::StaticContentController < Spree::BaseController
   caches_action :show, :cache_path => Proc.new { |controller|
-    "spree_static_content/" + controller.params[:path].to_s
+    "spree_static_content/" + controller.params[:path].to_s + "_spree_static_content"
   }
   
   layout :determine_layout


### PR DESCRIPTION
Ah, geez, I suck. When I made the fixes for the caching keys, there was a problem when trying to override the '/' page, in that the cache key would get unexpectedly changed when adding a cache fragment, and thus the caching wouldn't work.

Not to mention you'd get an exception even before that...but once you fixed the exception, it still wouldn't work.

In any case, the attached pull request fixes this. Recommend it be merged into 1-0-stable and master.
