### PR TITLE
disable caching

### DIFF
--- a/app/controllers/spree/admin/pages_controller.rb
+++ b/app/controllers/spree/admin/pages_controller.rb
@@ -1,5 +1,4 @@
 class Spree::Admin::PagesController < Spree::Admin::ResourceController
-  update.after :expire_cache
 
   def new
     @page = @object
@@ -9,8 +8,4 @@ class Spree::Admin::PagesController < Spree::Admin::ResourceController
     @page = @object
   end
 
-  private
-  def expire_cache
-    expire_fragment "spree_static_content" + @object.slug + "_spree_static_content"
-  end
 end

--- a/app/controllers/spree/static_content_controller.rb
+++ b/app/controllers/spree/static_content_controller.rb
@@ -1,7 +1,4 @@
 class Spree::StaticContentController < Spree::BaseController
-  caches_action :show, :cache_path => Proc.new { |controller|
-    "spree_static_content/" + controller.params[:path].to_s + "_spree_static_content"
-  }
 
   helper "spree/products"
   layout :determine_layout


### PR DESCRIPTION
Per #55, I think the caching is pretty broken in the current version of this gem, and can lead to inconsistent behavior.  This pull disables the caching completely until it can be re-implemented using fragment caching or some other mechanism.
