### PR TITLE
lookup still works now that the Rails bug #2579 with double hashes is fixed

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,12 @@
 module StaticPage
   def self.remove_spree_mount_point(path)
-    regex = Regexp.new Rails.application.routes.url_helpers.spree_path
-    path.sub( regex, '').split('?')[0]
+    spree_path = Rails.application.routes.url_helpers.spree_path
+    if spree_path == '/' # Spree is mounted as root
+      path.sub!( '//', '/') # this fixes a Rails bug
+    else
+      path.sub!( Regexp.new(spree_path), '')
+    end
+    path.split('?')[0]
   end
 end
 


### PR DESCRIPTION
There was a bug with older versions of Rails where if Spree was mounted as root, request.path would come back starting with '//'

https://github.com/rails/rails/issues/2579

This has been fixed and breaks the route lookup.  This patch should work for the buggy rails and the new fixed rails.
