### PR TITLE
Translation broken?

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2,7 +2,7 @@
 de:
   activerecord:
     attributes:
-      page: &page_labels
+      spree/page: &page_labels
         title: Titel
         slug: Pfad
         body: Inhalt

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,7 +2,7 @@
 en:
   activerecord:
     attributes:
-      page: &page_labels
+      spree/page: &page_labels
         title: Title
         slug: Slug
         body: Body

--- a/config/locales/es-ES.yml
+++ b/config/locales/es-ES.yml
@@ -2,7 +2,7 @@
 es-ES:
   activerecord:
     attributes:
-      page: &page_labels
+      spree/page: &page_labels
         title: Título
         slug: Slug
         body: Cuerpo

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2,7 +2,7 @@
 es:
   activerecord:
     attributes:
-      page: &page_labels
+      spree/page: &page_labels
         title: Título
         slug: Slug
         body: Cuerpo

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -2,7 +2,7 @@
 et:
   activerecord:
     attributes:
-      page:
+      spree/page:
         title: Pealkiri
         slug: Püsiviide
         body: Sisu

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -2,7 +2,7 @@
 it:
   activerecord:
     attributes:
-      page:
+      spree/page:
         title: Titolo
         slug: Slug
         body: Testo

--- a/config/locales/pt-PT.yml
+++ b/config/locales/pt-PT.yml
@@ -2,7 +2,7 @@
 pt-PT:
   activerecord:
     attributes:
-      page: &page_labels
+      spree/page: &page_labels
         title: Título
         slug: Slug
         body: Corpo

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -2,7 +2,7 @@
 ru:
   activerecord:
     attributes:
-      page:
+      spree/page:
         title: Заголовок
         slug: Постоянная ссылка
         body: Основной текст


### PR DESCRIPTION
Looks like the translation namespace has been broken after Page has been namespaced to spree module.
https://github.com/spree/spree_static_content/commit/06279837f6c771b52d77cd34b3f4e89b8d0a05f8#L10R13
I have pocked a bit around in the console and when we call 

``` ruby
Spree::Page.human_attribute_name(:title)
```

I18n searches for 

``` ruby
en.activerecord.attributes.spree/page.title
```

While in project translation files https://github.com/spree/spree_static_content/blob/master/config/locales/en.yml

```
en:
  activerecord:
    attributes:
      page: &page_labels
        title: Title 
```

Correct me if I'm wrong but I believe it should be

```
en:
  activerecord:
    attributes:
      spree/page: &page_labels
        title: Title 
```

If it does make sense I can fix all translation files unless someone has a better idea.
