### PR TITLE
Added table_exists? check for migration.

### DIFF
--- a/db/migrate/20111201184855_prefix_pages_table_name.rb
+++ b/db/migrate/20111201184855_prefix_pages_table_name.rb
@@ -1,5 +1,7 @@
 class PrefixPagesTableName < ActiveRecord::Migration
   def change
-    rename_table :pages, :spree_pages
+    if table_exists?(:pages)
+      rename_table :pages, :spree_pages
+    end
   end
 end


### PR DESCRIPTION
Users who have an old migration file name before it was renamed in #71 will have their migration fail when updating to 1-3-stable because it will copy over same migration with new file name, so we need to add a check for table existence.
