### PR TITLE
Allow users to opt out of automatic title rendering

### DIFF
--- a/app/models/spree/page.rb
+++ b/app/models/spree/page.rb
@@ -12,7 +12,7 @@ class Spree::Page < ActiveRecord::Base
 
   before_save :update_positions_and_slug
 
-  attr_accessible :title, :slug, :body, :meta_title, :meta_keywords, :meta_description, :layout, :foreign_link, :position, :show_in_sidebar, :show_in_header, :show_in_footer, :visible, :render_layout_as_partial
+  attr_accessible :title, :slug, :body, :meta_title, :meta_keywords, :meta_description, :layout, :foreign_link, :position, :show_in_sidebar, :show_in_header, :show_in_footer, :visible, :render_layout_as_partial, :render_title_automatically
 
   def self.by_slug(slug)
     slug = StaticPage::remove_spree_mount_point(slug)

--- a/app/views/spree/admin/pages/_form.html.erb
+++ b/app/views/spree/admin/pages/_form.html.erb
@@ -74,6 +74,10 @@
         <%= f.check_box :render_layout_as_partial %>
         <%= f.label :render_layout_as_partial %>
       </li>
+      <li>
+        <%= f.check_box :render_title_automatically %>
+        <%= f.label :render_title_automatically %>
+      </li>
     </ul>
 
   </div>

--- a/app/views/spree/static_content/show.html.erb
+++ b/app/views/spree/static_content/show.html.erb
@@ -19,7 +19,9 @@
     <% end %>
   <% end %>
 
-  <h1><%= @page.title %></h1>
+  <% if @page.render_title_automatically %>
+    <h1><%= @page.title %></h1>
+  <% end %>
   <div id="page_content">
     <%= raw @page.body %>
   </div>

--- a/db/migrate/20130520152500_add_render_title_automatically_to_spree_pages.rb
+++ b/db/migrate/20130520152500_add_render_title_automatically_to_spree_pages.rb
@@ -1,0 +1,6 @@
+class AddRenderTitleAutomaticallyToSpreePages < ActiveRecord::Migration
+  def change
+    add_column :spree_pages, :render_title_automatically, :boolean, :default => true
+    execute "UPDATE spree_pages SET render_title_automatically = true;"
+  end
+end


### PR DESCRIPTION
Figured it'd be nice to allow more design flexibilty and let users opt-out
of automatic title rendering. In order to maintain backwards compatibility
the migration adds the column, defaults it to yes, and then goes back through
all existing spree_pages rows and marks the boolean as true.
