### PR TITLE
Gemspec now depends on 2.1.0.beta

### DIFF
--- a/spree_static_content.gemspec
+++ b/spree_static_content.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 2.0.0'
+  s.add_dependency 'spree_core', '~> 2.1.0.beta'
 
   s.add_development_dependency 'capybara', '1.0.1'
   s.add_development_dependency 'factory_girl', '~> 4.2'


### PR DESCRIPTION
When trying to install master on a 2.1.0.beta store, bundler gives the message:

```
Bundler could not find compatible versions for gem "spree_core":
  In Gemfile:
    spree_static_content (>= 0) ruby depends on
      spree_core (~> 2.0.0) ruby

    spree (>= 0) ruby depends on
      spree_core (2.1.0.beta)
```

This should remedy that.
