### PR TITLE
Injects into the correct view

### DIFF
--- a/app/overrides/static_content_admin_tab.rb
+++ b/app/overrides/static_content_admin_tab.rb
@@ -1,4 +1,4 @@
-Deface::Override.new(:virtual_path => "spree/layouts/admin",
+Deface::Override.new(:virtual_path => "spree/admin/shared/_menu",
                      :name => "static_content_admin_tab",
                      :insert_bottom => "[data-hook='admin_tabs']",
                      :text => "<%= tab(:pages, :icon => 'icon-file') %>",


### PR DESCRIPTION
Admin tabs have been refactored in Spree to `spree/admin/shared/_menu.html.erb`.
