### PR TITLE
Rename page variable to static content to aid dynamic helpers

### DIFF
--- a/app/controllers/spree/static_content_controller.rb
+++ b/app/controllers/spree/static_content_controller.rb
@@ -13,7 +13,7 @@ class Spree::StaticContentController < Spree::StoreController
       request.path
     end
 
-    unless @page = Spree::Page.visible.by_slug(path).first
+    unless @static_content = Spree::Page.visible.by_slug(path).first
       render_404
     end
   end
@@ -21,12 +21,12 @@ class Spree::StaticContentController < Spree::StoreController
   private
 
   def determine_layout
-    return @page.layout if @page and @page.layout.present? and not @page.render_layout_as_partial?
+    return @static_content.layout if @static_content and @static_content.layout.present? and not @static_content.render_layout_as_partial?
     Spree::Config.layout
   end
 
   def accurate_title
-    @page ? (@page.meta_title.present? ? @page.meta_title : @page.title) : nil
+    @static_content ? (@static_content.meta_title.present? ? @static_content.meta_title : @static_content.title) : nil
   end
 
 end

--- a/app/views/spree/static_content/_static_content_footer.html.erb
+++ b/app/views/spree/static_content/_static_content_footer.html.erb
@@ -1,3 +1,3 @@
 <nav id="footer-pages">
-  <ul><%= render :partial => "spree/static_content/static_content_list", :collection => Spree::Page.visible.footer_links, :as => :page %></ul>
+  <ul><%= render :partial => "spree/static_content/static_content_list", :collection => Spree::Page.visible.footer_links, :as => :static_content %></ul>
 </nav>

--- a/app/views/spree/static_content/_static_content_header.html.erb
+++ b/app/views/spree/static_content/_static_content_header.html.erb
@@ -1,1 +1,1 @@
-<%= render :partial => "spree/static_content/static_content_list", :collection => Spree::Page.visible.header_links, :as => :page %>
+<%= render :partial => "spree/static_content/static_content_list", :collection => Spree::Page.visible.header_links, :as => :static_content %>

--- a/app/views/spree/static_content/_static_content_list.html.erb
+++ b/app/views/spree/static_content/_static_content_list.html.erb
@@ -1,7 +1,7 @@
-<% if page.foreign_link.present? %>
-  <li class='not'><%= link_to page.title, page.foreign_link, {:target => "_blank"} %></li>
+<% if static_content.foreign_link.present? %>
+  <li class='not'><%= link_to static_content.title, static_content.foreign_link, {:target => "_blank"} %></li>
 <% else %>
-  <% page_uri = Rails.application.routes.named_routes[:spree].path.spec.to_s == '/' ? page.slug : Rails.application.routes.named_routes[:spree].path.spec.to_s + page.slug %>
-  <li class=<%=(request.fullpath.gsub('//','/') == page_uri) ? 'current' : 'not'%>><%= link_to page.title, page_uri  %></li>
+  <% static_content_uri = Rails.application.routes.named_routes[:spree].path.spec.to_s == '/' ? static_content.slug : Rails.application.routes.named_routes[:spree].path.spec.to_s + static_content.slug %>
+  <li class=<%=(request.fullpath.gsub('//','/') == static_content_uri) ? 'current' : 'not'%>><%= link_to static_content.title, static_content_uri  %></li>
 <% end %>
 

--- a/app/views/spree/static_content/_static_content_sidebar.html.erb
+++ b/app/views/spree/static_content/_static_content_sidebar.html.erb
@@ -1,6 +1,6 @@
 <% if Spree::Page.visible.sidebar_links.any? %>
 <nav id="sidebar-pages-menu" class="sidebar-item">
   <h6 class="page-navigation-title"><%= Spree.t("static_content.page_navigation_title")%></h6>
-  <ul><%= render :partial => "spree/static_content/static_content_list", :collection => Spree::Page.visible.sidebar_links, :as => :page %></ul>
+  <ul><%= render :partial => "spree/static_content/static_content_list", :collection => Spree::Page.visible.sidebar_links, :as => :static_content %></ul>
 </nav>
 <% end %>

--- a/app/views/spree/static_content/show.html.erb
+++ b/app/views/spree/static_content/show.html.erb
@@ -1,16 +1,6 @@
-<% if @page.layout.present? and @page.render_layout_as_partial? %>
-  <%= render :partial => @page.layout %>
+<% if @static_content.layout.present? and @static_content.render_layout_as_partial? %>
+  <%= render :partial => @static_content.layout %>
 <% else %>
-  <% content_for :head do -%>
-    <%- if @page.meta_title.present? -%>
-      <meta name="title" content="<%=@page.meta_title%>">
-    <%- else -%>
-      <meta name="title" content="<%=@page.title%>">
-    <%- end -%>
-    <meta name="keywords" content="<%=@page.meta_keywords%>">
-    <meta name="description" content="<%=@page.meta_description%>">
-  <% end -%>
-
   <% content_for :sidebar do %>
     <% if "products" == @current_controller && @taxon %>
       <%= render :partial => "spree/shared/filters" %>
@@ -19,8 +9,8 @@
     <% end %>
   <% end %>
 
-  <h1><%= @page.title %></h1>
+  <h1><%= @static_content.title %></h1>
   <div id="page_content">
-    <%= raw @page.body %>
+    <%= raw @static_content.body %>
   </div>
 <% end %>


### PR DESCRIPTION
Some helpers such a `meta_data_tags` look for instance variables based on the current controller name. As the instance variable is named `@page` meta tags were being duplicated on the page and the default Spree ones being used in SERP pages.