### PR TITLE
Rails 4 strong parameter support

### DIFF
--- a/app/models/spree/page.rb
+++ b/app/models/spree/page.rb
@@ -8,14 +8,12 @@ class Spree::Page < ActiveRecord::Base
   validates :slug, :uniqueness => true, :if => :not_using_foreign_link?
   validates :foreign_link, :uniqueness => true, :allow_blank => true
 
-  scope :visible, where(:visible => true)
-  scope :header_links, where(:show_in_header => true).visible
-  scope :footer_links, where(:show_in_footer => true).visible
-  scope :sidebar_links, where(:show_in_sidebar => true).visible
+  scope :visible, -> { where(:visible => true) }
+  scope :header_links, -> { where(:show_in_header => true).visible }
+  scope :footer_links, -> { where(:show_in_footer => true).visible }
+  scope :sidebar_links, -> { where(:show_in_sidebar => true).visible }
 
   before_save :update_positions_and_slug
-
-  attr_accessible :title, :slug, :body, :meta_title, :meta_keywords, :meta_description, :layout, :foreign_link, :position, :show_in_sidebar, :show_in_header, :show_in_footer, :visible, :render_layout_as_partial
 
   def self.by_slug(slug)
     slug = StaticPage::remove_spree_mount_point(slug)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,17 +20,17 @@ class Spree::StaticRoot
   end
 end
 
-Spree::Core::Engine.routes.prepend do
+Spree::Core::Engine.routes.draw do
 
   namespace :admin do
     resources :pages
   end
 
   constraints(Spree::StaticRoot) do
-    match '/', :to => 'static_content#show', :via => :get, :as => 'static'
+    get '/', to: 'static_content#show', as: 'static_root'
   end
 
   constraints(Spree::StaticPage) do
-    match '/*path', :to => 'static_content#show', :via => :get, :as => 'static'
+    get '/*path', to: 'static_content#show', as: 'static_page'
   end
 end


### PR DESCRIPTION
Support for Rails 4 strong parameters. Extension can now be used with the master version of Spree.
