### PR TITLE
Do not unnecessarily strip leading slash

### DIFF
--- a/app/views/spree/static_content/_static_content_list.html.erb
+++ b/app/views/spree/static_content/_static_content_list.html.erb
@@ -1,7 +1,7 @@
 <% if page.foreign_link.present? %>
   <li class='not'><%= link_to page.title, page.foreign_link, {:target => "_blank"} %></li>
 <% else %>
-  <% page_uri = Rails.application.routes.named_routes[:spree].path.spec.to_s == '/' ? page.slug : Rails.application.routes.named_routes[:spree].path.spec.to_s + page.slug %>
+  <% page_uri = Rails.application.routes.named_routes[:spree].path.spec.to_s + page.slug %>
   <li class=<%=(request.fullpath.gsub('//','/') == page_uri) ? 'current' : 'not'%>><%= link_to page.title, page_uri  %></li>
 <% end %>
 


### PR DESCRIPTION
which leads to static page links being broken on deeper levels such as /producs/sss/
