### PR TITLE
Move Spree::StaticPage and Spree:StaticRoot to facilitate overrides with decorator

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,24 +1,24 @@
-module StaticPage
-  def self.remove_spree_mount_point(path)
-    regex = Regexp.new '\A' + Rails.application.routes.url_helpers.spree_path
-    path.sub( regex, '').split('?')[0]
-  end
-end
-
-class Spree::StaticPage
-  def self.matches?(request)
-    slug = StaticPage::remove_spree_mount_point(request.fullpath)
-    pages = Spree::Page.arel_table
-    Spree::Page.visible.by_slug(slug).exists?
-  end
-end
-
-class Spree::StaticRoot
-  def self.matches?(request)
-    path = StaticPage::remove_spree_mount_point(request.fullpath)
-    path.nil? && Spree::Page.visible.by_slug(path.to_s).first
-  end
-end
+# module StaticPage
+#   def self.remove_spree_mount_point(path)
+#     regex = Regexp.new '\A' + Rails.application.routes.url_helpers.spree_path
+#     path.sub( regex, '').split('?')[0]
+#   end
+# end
+# 
+# class Spree::StaticPage
+#   def self.matches?(request)
+#     slug = StaticPage::remove_spree_mount_point(request.fullpath)
+#     pages = Spree::Page.arel_table
+#     Spree::Page.visible.by_slug(slug).exists?
+#   end
+# end
+# 
+# class Spree::StaticRoot
+#   def self.matches?(request)
+#     path = StaticPage::remove_spree_mount_point(request.fullpath)
+#     path.nil? && Spree::Page.visible.by_slug(path.to_s).first
+#   end
+# end
 
 Spree::Core::Engine.routes.prepend do
 

--- a/lib/spree_static_content.rb
+++ b/lib/spree_static_content.rb
@@ -1,2 +1,24 @@
 require 'spree/core'
 require 'spree_static_content/engine'
+
+module StaticPage
+  def self.remove_spree_mount_point(path)
+    regex = Regexp.new '\A' + Rails.application.routes.url_helpers.spree_path
+    path.sub( regex, '').split('?')[0]
+  end
+end
+
+class Spree::StaticPage
+  def self.matches?(request)
+    slug = StaticPage::remove_spree_mount_point(request.fullpath)
+    pages = Spree::Page.arel_table
+    Spree::Page.visible.by_slug(slug).exists?
+  end
+end
+
+class Spree::StaticRoot
+  def self.matches?(request)
+    path = StaticPage::remove_spree_mount_point(request.fullpath)
+    path.nil? && Spree::Page.visible.by_slug(path.to_s).first
+  end
+end


### PR DESCRIPTION
Hi, we are working on a gem that enable static page localization. We need to override this two classes, but we are not able if they lives in routes.rb. 
Out gem link is [https://github.com/geekcups-team/spree_static_content_i18n](https://github.com/geekcups-team/spree_static_content_i18n)
