### PR TITLE
Added / to the start of the url

### DIFF
--- a/app/views/spree/static_content/_static_content_list.html.erb
+++ b/app/views/spree/static_content/_static_content_list.html.erb
@@ -1,6 +1,6 @@
 <% if page.foreign_link.present? %>
   <li><%= link_to page.title, page.foreign_link, {:target => "_blank"} %></li>
 <% else %>
-  <% page_uri = Rails.application.routes.named_routes[:spree].path.spec.to_s == '/' ? page.slug : Rails.application.routes.named_routes[:spree].path.spec.to_s + page.slug %>
+  <% page_uri = Rails.application.routes.named_routes[:spree].path.spec.to_s == '/' ? "/#{page.slug}" : Rails.application.routes.named_routes[:spree].path.spec.to_s + page.slug %>
   <li class=<%= 'current' if (request.fullpath.gsub('//','/') == page_uri) %>><%= link_to page.title, page_uri  %></li>
 <% end %>


### PR DESCRIPTION
When you have installed the Spree in the root of the domain, if you try to navigate to any page, the link for the page is append to the end. Example:

You are at /t/tag and the you try to press a link that goes to a page with a slug faq. It will go to /t/tag/faq. 

My solution have been to add in the link "/faq".