### PR TITLE
Adding ability to deface the table and form

### DIFF
--- a/app/views/spree/admin/pages/_form.html.erb
+++ b/app/views/spree/admin/pages/_form.html.erb
@@ -1,5 +1,6 @@
-<div class="row">
-  <div class="alpha ten columns">
+<div data-hook="admin_page_form_fields">
+
+  <div class="alpha ten columns" data-hook="admin_page_form_left">
     <%= f.field_container :title do %>
       <%= f.label :title %> <span class="required">*</span><br />
       <%= f.text_field :title, :class => 'fullwidth title' %>
@@ -19,7 +20,7 @@
     <% end %>
   </div>
   
-  <div class="omega six columns">
+  <div class="omega six columns" data-hook="admin_page_form_right">
     <%= f.field_container :meta_title do %>
       <%= f.label :meta_title %><br />
       <%= f.text_field :meta_title, :class => 'fullwidth title' %>
@@ -77,4 +78,9 @@
     </ul>
 
   </div>
+
+  <div class="clear"></div>
+  <div data-hook="admin_page_form_additional_fields"></div>
+  <div class="clear"></div>
+  
 </div>

--- a/app/views/spree/admin/pages/index.html.erb
+++ b/app/views/spree/admin/pages/index.html.erb
@@ -14,17 +14,17 @@
     <col style="width: 10%" />
   </colgroup>
   <thead>
-    <tr>
+    <tr data-hook="admin_pages_index_headers">
       <th><%= Spree::Page.human_attribute_name(:title) %></th>
       <th><%= Spree.t("static_content.link") %></th>
       <th><%= Spree::Page.human_attribute_name(:visible) %></th>
-      <th class="actions"></th>
+      <th data-hook="admin_pages_index_header_actions" class="actions"></th>
     </tr>
   </thead>
   
   <tbody>
     <% @pages.each do |page| %>
-      <tr class="<%= cycle('odd', 'even') %>" id="<%= dom_id page %>">
+      <tr data-hook="admin_pages_index_rows" class="<%= cycle('odd', 'even') %>" id="<%= dom_id page %>">
         <td>
           <%= page.title %>
         </td>
@@ -38,7 +38,7 @@
         <td class="align-center">
           <%= content_tag(:i, '', :class => 'icon-ok green') if page.visible %>
         </td>
-        <td  class="actions">
+        <td  class="actions" data-hook="admin_pages_index_row_actions">
           <%= link_to_edit page, :no_text => true %>
           <%= link_to_delete page, :no_text => true %>
         </td>


### PR DESCRIPTION
I saw that deface was included in the master branch but not on 2-1-stable. This uses the same deface data-hooks as in the master branch.
