### PR TITLE
Pull activerecord translations out of the spree namespace

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -28,6 +28,9 @@ de:
 
     page: Seite
     pages: Seiten
+    admin:
+      tab:
+        pages: Seiten
     static_content:
       static_pages: Statische Seiten
       static_pages_desc: Verwaltung statischer Seiten mit einem WYSIWYG-Editor


### PR DESCRIPTION
Activerecord translations wont work inside spree namespace...
