### PR TITLE
Fix incorrect sidebar conditions on 2-2-stable branch

### DIFF
--- a/app/views/spree/static_content/show.html.erb
+++ b/app/views/spree/static_content/show.html.erb
@@ -12,9 +12,9 @@
   <% end -%>
 
   <% content_for :sidebar do %>
-    <% if defined? @products && defined? @taxon %>
+    <% if @products & @taxon %>
       <%= render :partial => "spree/shared/filters" %>
-    <% elsif defined? @taxonomies %>
+    <% elsif @taxonomies %>
       <%= render :partial => "spree/shared/taxonomies" %>
     <% end %>
   <% end %>


### PR DESCRIPTION
Change 'defined?' check to 'defined and not nil' condition to prevent partials from being called when no valid data is available.

See #155 for fix in master.
