### PR TITLE
Make header, footer and sidebar links nofollow

### DIFF
--- a/app/views/spree/static_content/_static_content_list.html.erb
+++ b/app/views/spree/static_content/_static_content_list.html.erb
@@ -1,5 +1,5 @@
 <% if page.foreign_link.present? %>
-  <li class='not'><%= link_to page.title, page.foreign_link, {:target => "_blank"} %></li>
+  <li class='not'><%= link_to page.title, page.foreign_link, {:target => "_blank", :ref => "nofollow"} %></li>
 <% else %>
   <% page_uri = Rails.application.routes.named_routes[:spree].path.spec.to_s == '/' ? page.slug : Rails.application.routes.named_routes[:spree].path.spec.to_s + page.slug %>
   <li class=<%=(request.fullpath.gsub('//','/') == page_uri) ? 'current' : 'not'%>><%= link_to page.title, page_uri, :rel => "nofollow" %></li>


### PR DESCRIPTION
Some webmasters think that sidebar and nofollow links can be harmful and should be made nofollow. We think so too http://devblog.shopjoy.com.au/2014/04/nofollow-links-in-footer.html .
