### PR TITLE
fixed issue in extended page migration with the syntasis of the order ac...

### DIFF
--- a/db/migrate/20090625125735_extend_pages.rb
+++ b/db/migrate/20090625125735_extend_pages.rb
@@ -9,9 +9,9 @@ class ExtendPages < ActiveRecord::Migration
       t.string  :foreign_link
       t.integer :position, :default => 1, :null => false
       if Page.table_exists?
-        Page.all(:order => "updated_at ASC").each_with_index{|page,x| page.update_attribute(:position, x+1)}
+        Page.all.order("updated_at ASC").each_with_index{|page,x| page.update_attribute(:position, x+1)}
       else
-        Spree::Page.all(:order => "updated_at ASC").each_with_index{|page,x| page.update_attribute(:position, x+1)}
+        Spree::Page.all.order("updated_at ASC").each_with_index{|page,x| page.update_attribute(:position, x+1)}
       end
 
     end


### PR DESCRIPTION
I had an error running the extended_page migration in spree/master. I try fix the issue changed the syntaxis of order active record method.
