### PR TITLE
Remove the "require spree/frontend" directive from the main css.

### DIFF
--- a/app/assets/stylesheets/spree/frontend/spree_static_content.css
+++ b/app/assets/stylesheets/spree/frontend/spree_static_content.css
@@ -1,7 +1,3 @@
-/*
- *= require spree/frontend
-*/
-
 /* Sidebar - .list-group-item styles */
 .pages-list.list-group > li:last-child {
   margin-bottom: 0;


### PR DESCRIPTION
Spree applications that use different fronted stylesheets cannot use spree_static_content without including the spree/frontend css, this can ruin their whole layout (for example: a Spree app that uses the [spree_bootstrap_frontend](https://github.com/200Creative/spree_bootstrap_frontend) extension). 
I think this can be safely removed because spree/frontend is included by default in every Spree app.