### PR TITLE
Fixed not-found error if using a mount-path for the Spree engine.

### DIFF
--- a/app/controllers/spree/static_content_controller.rb
+++ b/app/controllers/spree/static_content_controller.rb
@@ -5,7 +5,7 @@ class Spree::StaticContentController < Spree::StoreController
   layout :determine_layout
 
   def show
-    @page = Spree::Page.by_store(current_store).visible.find_by_slug!(request.path)
+    @page = Spree::Page.by_store(current_store).visible.slug_relative_to_mount_point(request.path).first
   end
 
   private

--- a/app/controllers/spree/static_content_controller.rb
+++ b/app/controllers/spree/static_content_controller.rb
@@ -5,7 +5,7 @@ class Spree::StaticContentController < Spree::StoreController
   layout :determine_layout
 
   def show
-    @page = Spree::Page.by_store(current_store).visible.slug_relative_to_mount_point(request.path).first
+    @page = Spree::Page.by_store(current_store).visible.slug_relative_to_mount_point(request.path).first!
   end
 
   private

--- a/app/models/spree/page.rb
+++ b/app/models/spree/page.rb
@@ -14,6 +14,15 @@ class Spree::Page < ActiveRecord::Base
   scope :header_links, -> { where(:show_in_header => true).visible }
   scope :footer_links, -> { where(:show_in_footer => true).visible }
   scope :sidebar_links, -> { where(:show_in_sidebar => true).visible }
+  scope :slug_relative_to_mount_point, lambda { |request_path|
+    # Remove Spree engine mount point from the path.
+    spree_path_regex_str = Rails.application.routes.named_routes[:spree].path.source
+    spree_path_regex = Regexp.new(spree_path_regex_str)
+    path = request_path.gsub(spree_path_regex, "")
+
+    # Match slug to path without Spree engine mount point.
+    where(:slug => path)
+  }
 
   scope :by_store, lambda { |store| joins(:stores).where("spree_pages_stores.store_id = ?", store) }
 

--- a/app/models/spree/page.rb
+++ b/app/models/spree/page.rb
@@ -17,8 +17,12 @@ class Spree::Page < ActiveRecord::Base
   scope :slug_relative_to_mount_point, lambda { |request_path|
     # Remove Spree engine mount point from the path.
     spree_path_regex_str = Rails.application.routes.named_routes[:spree].path.source
-    spree_path_regex = Regexp.new(spree_path_regex_str)
-    path = request_path.gsub(spree_path_regex, "")
+    if spree_path_regex_str == "\\A/"
+      path = request_path
+    else
+      spree_path_regex = Regexp.new(spree_path_regex_str)
+      path = request_path.gsub(spree_path_regex, "")
+    end
 
     # Match slug to path without Spree engine mount point.
     where(:slug => path)

--- a/lib/spree_static_content.rb
+++ b/lib/spree_static_content.rb
@@ -13,6 +13,6 @@ end
 class Spree::StaticPage
   def self.matches?(request)
     return false if request.path =~ /(^\/+(admin|account|cart|checkout|content|login|pg\/|orders|products|s\/|session|signup|shipments|states|t\/|tax_categories|user)+)/
-    !Spree::Page.visible.find_by_slug(request.path).nil?
+    Spree::Page.visible.slug_relative_to_mount_point(request.path).any?
   end
 end


### PR DESCRIPTION
Pages could not be found, if Spree wasn't mounted at root "/".

Fixed this by making a new scope, that removes the mounted path from the request path, and then looks for a page with that slug.