### PR TITLE
fix: Deface override ul for pages in header

### DIFF
--- a/app/overrides/pages_in_header.rb
+++ b/app/overrides/pages_in_header.rb
@@ -1,5 +1,5 @@
 Deface::Override.new(:virtual_path => "spree/shared/_main_nav_bar",
                      :name => "pages_in_header",
-                     :insert_bottom => "#main-nav-bar",
+                     :insert_bottom => "#main-nav-bar > ul:first-child",
                      :partial => "spree/static_content/static_content_header",
                      :disabled => false)


### PR DESCRIPTION
Fixed the content of app/overrides/pages_in_header.rb from

> :insert_bottom => "#main-nav-bar

to

> :insert_bottom => "#main-nav-bar > ul:first-child"