### PR TITLE
resource names pluralization compatible with latest spree changes 

### DIFF
--- a/app/views/spree/admin/pages/_form.html.erb
+++ b/app/views/spree/admin/pages/_form.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Page.model_name.human(count: :many)), spree.admin_pages_path, icon: 'arrow-left', class: 'btn-primary' %>
+  <%= button_link_to Spree.t(:back_to_resource_list, resource: plural_resource_name(Spree::Page)), spree.admin_pages_path, icon: 'arrow-left', class: 'btn-primary' %>
 <% end %>
 
 <%= form_for [:admin, resource] do |f| %>
@@ -76,7 +76,7 @@
       </div>
 
       <div class="form-group">
-        <%= f.label :stores, Spree::Store.model_name.human(count: :many) %>
+        <%= f.label :stores, plural_resource_name(Spree::Store) %>
         <% Spree::Store.all.each do |store| %>
           <div class="checkbox">
             <%= f.label store.name.downcase.to_sym do %>

--- a/app/views/spree/admin/pages/index.html.erb
+++ b/app/views/spree/admin/pages/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::Page.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::Page) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/app/views/spree/admin/shared/_pages_sidebar_menu.erb
+++ b/app/views/spree/admin/shared/_pages_sidebar_menu.erb
@@ -1,5 +1,5 @@
 <% if can? :admin, Spree::Page %>
   <ul class="nav nav-sidebar">
-    <%= tab Spree::Page, url: spree.admin_pages_url, icon: 'leaf', label: Spree::Page.model_name.human(count: :many) %>
+    <%= tab Spree::Page, url: spree.admin_pages_url, icon: 'leaf', label: plural_resource_name(Spree::Page) %>
   </ul>
 <% end %>

--- a/app/views/spree/static_content/_static_content_sidebar.html.erb
+++ b/app/views/spree/static_content/_static_content_sidebar.html.erb
@@ -1,7 +1,7 @@
 <% if Spree::Page.by_store(current_store).visible.sidebar_links.any? %>
   <nav id="pages" class="sidebar-item">
     <h4 class="pages-root filter-title">
-      <%= Spree::Page.model_name.human(count: :many) %>
+      <%= plural_resource_name(Spree::Page) %>
     </h4>
     <ul class="pages-list list-group">
       <%= render partial: 'spree/static_content/static_content_list', collection: Spree::Page.visible.sidebar_links, as: :page %>


### PR DESCRIPTION
This fix is related to: https://github.com/spree/spree/pull/6059 and it is for compatibility with i18n.

Please merge it to master.