### PR TITLE
Fix header navigation and remove sidebar

### DIFF
--- a/app/overrides/pages_in_header.rb
+++ b/app/overrides/pages_in_header.rb
@@ -1,5 +1,5 @@
 Deface::Override.new(:virtual_path => "spree/shared/_main_nav_bar",
                      :name => "pages_in_header",
-                     :insert_bottom => "#main-nav-bar",
+                     :insert_after => "#home-link",
                      :partial => "spree/static_content/static_content_header",
                      :disabled => false)

--- a/app/views/spree/static_content/show.html.erb
+++ b/app/views/spree/static_content/show.html.erb
@@ -11,14 +11,6 @@
     <meta name="description" content="<%=@page.meta_description%>">
   <% end -%>
 
-  <% content_for :sidebar do %>
-    <% if defined? @products && defined? @taxon %>
-      <%= render :partial => "spree/shared/filters" %>
-    <% elsif defined? @taxonomies %>
-      <%= render :partial => "spree/shared/taxonomies" %>
-    <% end %>
-  <% end %>
-
   <h1><%= @page.title %></h1>
   <div id="page_content">
     <%= raw @page.body %>


### PR DESCRIPTION
* Header navigation bar was adding outside a <ul> now adds after home <li>
* Side bar features were not usable - removed.