### PR TITLE
Allow matching of taxon pages

### DIFF
--- a/lib/spree_static_content.rb
+++ b/lib/spree_static_content.rb
@@ -12,7 +12,7 @@ end
 
 class Spree::StaticPage
   def self.matches?(request)
-    return false if request.path =~ /(^\/+(admin|account|cart|checkout|content|login|pg\/|orders|products|s\/|session|signup|shipments|states|t\/|tax_categories|user)+)/
+    return false if request.path =~ /(^\/+(admin|account|cart|checkout|content|login|pg\/|orders|products|s\/|session|signup|shipments|states\/|tax_categories|user)+)/
     !Spree::Page.visible.find_by_slug(request.path).nil?
   end
 end


### PR DESCRIPTION
This restores the ability to override taxon pages with URLs in the form

/t/...

This ability is described in the readme, and used to work...with this PR, it does again! :-)

Fixes #188 