### PR TITLE
Backport pages_in_headers.rb from master branch

### DIFF
--- a/app/overrides/pages_in_header.rb
+++ b/app/overrides/pages_in_header.rb
@@ -1,5 +1,5 @@
 Deface::Override.new(:virtual_path => "spree/shared/_main_nav_bar",
                      :name => "pages_in_header",
-                     :insert_bottom => "#main-nav-bar",
+                     :insert_bottom => "#main-nav-bar > ul:first-child",
                      :partial => "spree/static_content/static_content_header",
                      :disabled => false)


### PR DESCRIPTION
Fixes #196 (wrong `<li>` element injection)