### PR TITLE
fix deface warning

### DIFF
--- a/lib/spree_static_content/engine.rb
+++ b/lib/spree_static_content/engine.rb
@@ -7,9 +7,6 @@ module SpreeStaticContent
     config.autoload_paths += %W(#{config.root}/lib)
 
     def self.activate
-      Dir.glob(%W(#{config.root}/app/overrides/*.rb)) do |klass|
-        Rails.configuration.cache_classes ? require(klass) : load(klass)
-      end
     end
 
     config.to_prepare(&method(:activate).to_proc)


### PR DESCRIPTION
I face some warning about spree_static_content when run `rake deface:precompile`
See https://github.com/spree/deface/issues/76
Thanks