### PR TITLE
Backport fixes for #184 and #185

### DIFF
--- a/app/overrides/pages_in_header.rb
+++ b/app/overrides/pages_in_header.rb
@@ -1,5 +1,5 @@
 Deface::Override.new(:virtual_path => "spree/shared/_main_nav_bar",
                      :name => "pages_in_header",
-                     :insert_bottom => "#main-nav-bar",
+                     :insert_bottom => "#main-nav-bar > ul:first-child",
                      :partial => "spree/static_content/static_content_header",
                      :disabled => false)


### PR DESCRIPTION
 as they affect spree_static_content 3.0 used with spree 3.0