### PR TITLE
Update development dependency and remove hound deprecation warning

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -8,7 +8,7 @@ Style/Documentation:
   Enabled: false
 
 # Neatly aligned code is to swell.
-Style/SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: false
 
 # Don't mess with RSpec DSL.

--- a/spree_static_content.gemspec
+++ b/spree_static_content.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'spree_core', '~> 3.1.0.beta'
 
-  s.add_development_dependency 'capybara', '~> 2.4'
+  s.add_development_dependency 'capybara', '~> 2.5'
   s.add_development_dependency 'factory_girl', '~> 4.4'
   s.add_development_dependency 'ffaker', '>= 1.25.0'
   s.add_development_dependency 'database_cleaner', '~> 1.4'


### PR DESCRIPTION
- Updated development dependencies.
- Replace deprecated SingleSpaceBeforeFirstArg with SpaceBeforeFirstArg for hound