### PR TITLE
Set spree_core to >= 3.1.0 and < 4.0 versions

### DIFF
--- a/spree_static_content.gemspec
+++ b/spree_static_content.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 3.2.0.alpha'
+  s.add_dependency 'spree_core', '>= 3.1.0', '< 4.0'
 
   s.add_development_dependency 'capybara', '~> 2.5'
   s.add_development_dependency 'factory_girl', '~> 4.4'


### PR DESCRIPTION
This PR changes the version of `spree_core` in gemspec to point at `>= 3.1.0` and `< 4.0`.