### PR TITLE
Replace add_routes with routes.draw

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-Spree::Core::Engine.add_routes do
+Spree::Core::Engine.routes.draw do
   namespace :admin do
     resources :pages
   end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/158492009

`add_routes` is deprecated, so i replaced it with `routes.draw`