### PR TITLE
Makes sidebar menu deface override work with both Spree 3.x and 4.x

### DIFF
--- a/app/overrides/add_pages_to_admin_sidebar_menu.rb
+++ b/app/overrides/add_pages_to_admin_sidebar_menu.rb
@@ -1,6 +1,15 @@
-Deface::Override.new(
-  virtual_path: 'spree/admin/shared/_main_menu',
-  name: 'pages_admin_sidebar_menu',
-  insert_bottom: 'nav',
-  partial: 'spree/admin/shared/pages_sidebar_menu'
-)
+if Spree.version.to_f < 4.0
+  Deface::Override.new(
+    virtual_path: 'spree/layouts/admin',
+    name: 'pages_admin_sidebar_menu',
+    insert_bottom: '#main-sidebar',
+    partial: 'spree/admin/shared/pages_sidebar_menu'
+  )
+else
+  Deface::Override.new(
+    virtual_path: 'spree/admin/shared/_main_menu',
+    name: 'pages_admin_sidebar_menu',
+    insert_bottom: 'nav',
+    partial: 'spree/admin/shared/pages_sidebar_menu'
+  )
+end


### PR DESCRIPTION
Fixes #266