### PR TITLE
Better handle locale in request.path - solve #268

### DIFF
--- a/app/controllers/spree/static_content_controller.rb
+++ b/app/controllers/spree/static_content_controller.rb
@@ -4,7 +4,7 @@ module Spree
     layout :determine_layout
 
     def show
-      @page = Spree::StaticPage.finder_scope.by_store(current_store).find_by!(slug: request.path)
+      @page = Spree::StaticPage.finder_scope.by_store(current_store).find_by!(slug: [params[:path], "/#{params[:path]}"])
     end
 
     private

--- a/app/models/spree/page.rb
+++ b/app/models/spree/page.rb
@@ -38,8 +38,6 @@ class Spree::Page < ActiveRecord::Base
   private
 
   def update_positions_and_slug
-    # Ensure that all slugs start with a slash.
-    slug.prepend('/') if not_using_foreign_link? && !slug.start_with?('/')
     return if new_record?
     return unless (prev_position = Spree::Page.find(id).position)
     if prev_position > position

--- a/lib/spree_static_content.rb
+++ b/lib/spree_static_content.rb
@@ -17,12 +17,13 @@ end
 module Spree
   class StaticPage
     def self.matches?(request)
-      return false if request.path =~ %r{\A\/+(admin|account|cart|checkout|content|login|pg\/|orders|products|s\/|session|signup|shipments|states|t\/|tax_categories|user)+}
-      !self.finder_scope.find_by(slug: request.path).nil?
+      path = request.path_parameters[:path]
+      return false if path =~ %r{\A+(admin|account|cart|checkout|content|login|pg\/|orders|products|s\/|session|signup|shipments|states|t\/|tax_categories|user)+}
+      !self.finder_scope.find_by(slug: [path, "/#{path}"]).nil?
     end
 
     protected
-    
+
     def self.finder_scope
       scope = Spree::Page.visible
       scope = scope.joins(:translations) if defined?(SpreeGlobalize)

--- a/spec/lib/spree_static_content_spec.rb
+++ b/spec/lib/spree_static_content_spec.rb
@@ -11,19 +11,19 @@ RSpec.describe Spree::StaticPage do
   context '.matches?' do
     it 'is true when valid page' do
       page = create(:page, slug: 'hello', visible: true)
-      request = double('request', path: page.slug)
+      request = double('request', path_parameters: {path: page.slug})
       expect(described_class.matches?(request)).to be true
     end
 
     it 'is false when using reserved slug name' do
       page = create(:page, slug: 'login', visible: true)
-      request = double('request', path: page.slug)
+      request = double('request', path_parameters: {path: page.slug})
       expect(described_class.matches?(request)).to be false
     end
 
     it 'is false when page is not accessible' do
       page = create(:page, slug: 'hello', visible: false)
-      request = double('request', path: page.slug)
+      request = double('request', path_parameters: {path: page.slug})
       expect(described_class.matches?(request)).to be false
     end
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -7,11 +7,6 @@ RSpec.describe Spree::Page, type: :model do
     end
   end
 
-  it 'always add / prefix to slug' do
-    page = create(:page, slug: 'hello')
-    expect(page.slug).to eq '/hello'
-  end
-
   context '.link' do
     it 'returns slug if foreign_link blank' do
       page = create(:page, slug: 'hello')


### PR DESCRIPTION
I modified the code a bit to better handle locale (fr, en) in request path. 

I also removed the '/' that was automatically added at the beginning of a slug for two reasons: 
- First, I don't see why is that necessary, I think this was because of the use of "request.path" which always starts with a '/'. As my pull request doesn't user request.path anymore, adding the '/' isn't necessary anymore - I think. 
- Second, it adds the '/' only for the default locale. Slug is a translatable field, and the '/' isn't automatically added for other languages, so that is a little bit weird. 

To keep a backward compatibility, I added `[path, "/#{path]"]` in Spree::Page find methods. 
I updated rspecs accordingly and they are all passing.

I wondered if I should also add a unit test for locale in path? You tell me. 