### PR TITLE
We don't use either coffee script or sass in this extension

### DIFF
--- a/lib/spree_static_content.rb
+++ b/lib/spree_static_content.rb
@@ -1,8 +1,6 @@
 require 'spree_core'
 require 'spree_static_content/engine'
 require 'spree_static_content/version'
-require 'coffee_script'
-require 'sass/rails'
 require 'spree_extension'
 
 module StaticPage


### PR DESCRIPTION
fixes errors such as https://spree-commerce.slack.com/archives/C0JCDUK0D/p1571343660041500