### PR TITLE
Added missing deface requirement

### DIFF
--- a/lib/spree_static_content.rb
+++ b/lib/spree_static_content.rb
@@ -2,6 +2,7 @@ require 'spree_core'
 require 'spree_static_content/engine'
 require 'spree_static_content/version'
 require 'spree_extension'
+require 'deface'
 
 module StaticPage
   module_function


### PR DESCRIPTION
As deface was removed from Spree some time ago, extensions still using it need to require it manually