### PR TITLE
[NUT-316] change order of choosing page title

### DIFF
--- a/app/views/spree/static_content/show.html.erb
+++ b/app/views/spree/static_content/show.html.erb
@@ -3,9 +3,9 @@
 <% else %>
   <% content_for :head do -%>
     <%- if @page.meta_title.present? -%>
-      <meta name="title" content="<%= @page.meta_title %>">
-    <%- else -%>
       <meta name="title" content="<%= @page.title %>">
+    <%- else -%>
+      <meta name="title" content="<%= @page.meta_title %>">
     <%- end -%>
     <meta name="keywords" content="<%= @page.meta_keywords %>">
     <meta name="description" content="<%= @page.meta_description %>">


### PR DESCRIPTION
Page title should have higher priorority than page meta title.